### PR TITLE
✨feat: Account 도메인 생성 및 로그인, 회원가입 Dto, User엔티티 생성(#3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,11 +26,25 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Swagger
+    // http://localhost:8080/swagger-ui/index.html#/
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.6.0'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/likelion/zagabi/Domain/Account/Dto/Request/UserLoginRequestDto.java
+++ b/src/main/java/org/likelion/zagabi/Domain/Account/Dto/Request/UserLoginRequestDto.java
@@ -1,0 +1,20 @@
+package org.likelion.zagabi.Domain.Account.Dto.Request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UserLoginRequestDto(
+        @NotBlank(message = "[ERROR] 이메일 입력은 필수입니다.")
+        @Schema(description = "email", example = "test1234@naver.com")
+        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "[ERROR] 이메일 형식에 맞지 않습니다.")
+        String email,
+
+        @NotBlank(message = "[ERROR] 비밀번호 입력은 필수 입니다.")
+        @Size(min = 8, message = "[ERROR] 비밀번호는 최소 8자리 이이어야 합니다.")
+        @Schema(description = "password", example = "test1234!!")
+        @Pattern(regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*]).{8,64}$", message = "[ERROR] 비밀번호는 8자 이상, 64자 이하이며 특수문자 한 개를 포함해야 합니다.")
+        String password
+) {
+}

--- a/src/main/java/org/likelion/zagabi/Domain/Account/Dto/Request/UserSignUpRequestDto.java
+++ b/src/main/java/org/likelion/zagabi/Domain/Account/Dto/Request/UserSignUpRequestDto.java
@@ -1,0 +1,41 @@
+package org.likelion.zagabi.Domain.Account.Dto.Request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.likelion.zagabi.Domain.Account.Entity.User;
+
+public record UserSignUpRequestDto(
+        @Size(max = 10, message = "닉네임은 최대 10자까지 입력 가능합니다.")
+        @Schema(description = "name", example = "멋쟁이슴우")
+        @NotBlank(message = "[ERROR] 닉네임 입력은 필수 입니다.")
+        String nickName,
+
+        @NotBlank(message = "[ERROR] 이메일 입력은 필수입니다.")
+        @Schema(description = "email", example = "test1234@naver.com")
+        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "[ERROR] 이메일 형식에 맞지 않습니다.")
+        String email,
+
+        @NotBlank(message = "[ERROR] 비밀번호 입력은 필수 입니다.")
+        @Size(min = 8, message = "[ERROR] 비밀번호는 최소 8자리 이이어야 합니다.")
+        @Schema(description = "password", example = "test1234!!")
+        @Pattern(regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*]).{8,64}$", message = "[ERROR] 비밀번호는 8자 이상, 64자 이하이며 특수문자 한 개를 포함해야 합니다.")
+        String password,
+
+        @NotBlank(message = "[ERROR] 비밀번호 재확인 입력은 필수 입니다.")
+        @Schema(description = "passwordCheck", example = "test1234!!")
+        String passwordCheck,
+
+        @NotBlank(message = "[ERROR] 비밀번호 재확인 입력은 필수 입니다.")
+        @Schema(description = "securityAnswer", example = "상명대 제1공학관")
+        String securityAnswer
+) {
+    public User toEntity(String encodedPw) {
+        return User.builder()
+                .email(email)
+                .password(encodedPw)
+                .nickname(nickName)
+                .build();
+    }
+}

--- a/src/main/java/org/likelion/zagabi/Domain/Account/Dto/Request/UserSignUpRequestDto.java
+++ b/src/main/java/org/likelion/zagabi/Domain/Account/Dto/Request/UserSignUpRequestDto.java
@@ -25,11 +25,7 @@ public record UserSignUpRequestDto(
 
         @NotBlank(message = "[ERROR] 비밀번호 재확인 입력은 필수 입니다.")
         @Schema(description = "passwordCheck", example = "test1234!!")
-        String passwordCheck,
-
-        @NotBlank(message = "[ERROR] 비밀번호 재확인 입력은 필수 입니다.")
-        @Schema(description = "securityAnswer", example = "상명대 제1공학관")
-        String securityAnswer
+        String passwordCheck
 ) {
     public User toEntity(String encodedPw) {
         return User.builder()

--- a/src/main/java/org/likelion/zagabi/Domain/Account/Entity/User.java
+++ b/src/main/java/org/likelion/zagabi/Domain/Account/Entity/User.java
@@ -1,0 +1,33 @@
+package org.likelion.zagabi.Domain.Account.Entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.*;
+import lombok.*;
+import org.likelion.zagabi.Global.Common.BaseEntity;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "user")
+public class User extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id", nullable = false)
+    private Long id;
+
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Column(name = "password")
+    private String password;
+
+    @Column(name = "nickname", nullable = false, length = 20)
+    private String nickname;
+
+    @Column(name="security_answer", nullable = false)
+    private String securityAnswer;
+
+}

--- a/src/main/java/org/likelion/zagabi/Domain/Account/Repository/UserJpaRepository.java
+++ b/src/main/java/org/likelion/zagabi/Domain/Account/Repository/UserJpaRepository.java
@@ -1,0 +1,7 @@
+package org.likelion.zagabi.Domain.Account.Repository;
+
+import org.likelion.zagabi.Domain.Account.Entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/org/likelion/zagabi/Domain/Account/Service/UserService.java
+++ b/src/main/java/org/likelion/zagabi/Domain/Account/Service/UserService.java
@@ -1,0 +1,5 @@
+package org.likelion.zagabi.Domain.Account.Service;
+
+public class UserService {
+
+}

--- a/src/main/java/org/likelion/zagabi/Global/Common/BaseEntity.java
+++ b/src/main/java/org/likelion/zagabi/Global/Common/BaseEntity.java
@@ -1,0 +1,22 @@
+package org.likelion.zagabi.Global.Common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
# ☝️Issue Number 6

- # #3 

# 🔎 Key Changes
- User 엔티티 생성
- 로그인, 회원가입 RequestDto 생성
- build.gradle에 의존성 추가(swagger, redis, validation)

# 💌 To Reviewers
- 피드백 부탁드립니다!
